### PR TITLE
Fix various coding problems in Python 3, especially exportimport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Fixed NotFound error when redirect_url started with a slash, for example ``/headerlogin``.
+  In local development it would redirect to /headerlogin on the Zope root, where it does not exist.
+  We now always treat the redirect_url as relative to the Plone site root, unless it is a full url.
+  [maurits]
+
 - Fixed exportimport to always set native strings.
   On Python 3 we were setting bytes, which was wrong.
   Fixed same problem in member properties.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- We require ``six>=1.12.0`` because we use ``ensure_str``.
+  Note that Plone 4.3 and 5.1 currently pin older versions.
+  [maurits]
+
 - Fixed NotFound error when redirect_url started with a slash, for example ``/headerlogin``.
   In local development it would redirect to /headerlogin on the Zope root, where it does not exist.
   We now always treat the redirect_url as relative to the Plone site root, unless it is a full url.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 ------------------
 
 - Fixed exportimport to always set native strings.
-  On Python 3 we were setting bytes, which was wrong.  [maurits]
+  On Python 3 we were setting bytes, which was wrong.
+  Fixed same problem in member properties.
+  [maurits]
 
 
 1.2.0 (2020-02-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed exportimport to always set native strings.
+  On Python 3 we were setting bytes, which was wrong.  [maurits]
 
 
 1.2.0 (2020-02-24)

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,7 @@ These are the properties that you can edit:
     When set, the Challenge plugin redirects unauthorized users to this url.
     Usually you would configure your frontend server to force SAML or CAS login on this url.
     The ``headerlogin`` page defined by this plugin may be a good url.
+    We treat the redirect_url as relative to the Plone site root, unless it is a full url.
     If ``deny_unauthorized`` is true, this option is ignored.
 
 ``memberdata_to_header``:

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,3 +8,4 @@ package-extras = [test]
 [versions]
 setuptools = 41.2.0
 zc.buildout = 2.13.2
+six = >= 1.12.0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'Products.GenericSetup>=1.8.2',
         'Products.PluggableAuthService',
         'setuptools',
-        'six',
+        'six>=1.12.0',
     ],
     extras_require={
         'test': [

--- a/src/pas/plugins/headers/exportimport.py
+++ b/src/pas/plugins/headers/exportimport.py
@@ -2,9 +2,9 @@
 from pas.plugins.headers.plugins import HeaderPlugin
 from pas.plugins.headers.utils import get_plugin
 from pas.plugins.headers.utils import PLUGIN_ID
+from pas.plugins.headers.utils import safe_make_string
 
 import json
-import six
 
 
 FILENAME = 'pas.plugins.headers.json'
@@ -42,11 +42,8 @@ def import_properties(context):
             continue
         # When saving in the ZMI, you always get a string,
         # so we want this for import too.
-        if isinstance(prop_value, six.text_type):
-            prop_value = prop_value.encode('utf-8')
-        elif isinstance(prop_value, list):
-            if prop_value and isinstance(prop_value[0], six.text_type):
-                prop_value = [v.encode('utf-8') for v in prop_value]
+        # So on Python 2 it is bytes, on Python 3 it is text.
+        prop_value = safe_make_string(prop_value)
         logger.debug('Setting %s to %r', prop_name, prop_value)
         # Note that lists are automatically turned into tuples.
         plugin._setPropValue(prop_name, prop_value)

--- a/src/pas/plugins/headers/plugins.py
+++ b/src/pas/plugins/headers/plugins.py
@@ -122,7 +122,8 @@ class HeaderPlugin(BasePlugin):
         A challenge is only tried when you are unauthorized.
         """
         if self.deny_unauthorized:
-            # We do not give the user a change to login.
+            # We do not give the user a chance to login.
+            # Yes, this must be bytes, not 'str' on Python 3.
             response.write(
                 b'ERROR: denying any unauthorized access.\n')
             return True

--- a/src/pas/plugins/headers/tests/test_exportimport.py
+++ b/src/pas/plugins/headers/tests/test_exportimport.py
@@ -119,23 +119,23 @@ class TestImport(ExportImportBaseTestCase):
         self.assertTupleEqual(
             self.plugin.allowed_roles,
             (
-                b'Member',
-                b'Zebra',
+                'Member',
+                'Zebra',
             ),
         )
         self.assertTrue(self.plugin.deny_unauthorized)
         self.assertTupleEqual(
             self.plugin.memberdata_to_header,
             (
-                b'uid|HEADER_uid|lower',
-                b'fullname|HEADER_firstname HEADER_lastname',
+                'uid|HEADER_uid|lower',
+                'fullname|HEADER_firstname HEADER_lastname',
             ),
         )
         self.assertEqual(
-            self.plugin.redirect_url, b'https://maurits.vanrees.org')
-        self.assertTupleEqual(self.plugin.required_headers, (b'uid', b'test'))
-        self.assertEqual(self.plugin.roles_header, b'roles')
-        self.assertEqual(self.plugin.userid_header, b'uid')
+            self.plugin.redirect_url, 'https://maurits.vanrees.org')
+        self.assertTupleEqual(self.plugin.required_headers, ('uid', 'test'))
+        self.assertEqual(self.plugin.roles_header, 'roles')
+        self.assertEqual(self.plugin.userid_header, 'uid')
 
     def test_import_no_file(self):
         """When the import file is not there, nothing should go wrong."""
@@ -169,40 +169,40 @@ class TestImport(ExportImportBaseTestCase):
         import_properties(self._makeContext(json.dumps(settings)))
         self.assertTupleEqual(
             self.plugin.allowed_roles,
-            (b'missile', b'target'),
+            ('missile', 'target'),
         )
         self.assertTrue(self.plugin.deny_unauthorized)
         self.assertTupleEqual(
             self.plugin.memberdata_to_header,
             (
-                b'uid|PROFILE_uid',
-                b'fullname|PROFILE_firstname PROFILE_lastname',
-                b'role|PROFILE_role|lower',
+                'uid|PROFILE_uid',
+                'fullname|PROFILE_firstname PROFILE_lastname',
+                'role|PROFILE_role|lower',
             ),
         )
         self.assertEqual(
-            self.plugin.redirect_url, b'https://maurits.vanrees.org')
+            self.plugin.redirect_url, 'https://maurits.vanrees.org')
         self.assertTupleEqual(
             self.plugin.required_headers,
-            (b'uid', b'role'),
+            ('uid', 'role'),
         )
-        self.assertEqual(self.plugin.roles_header, b'portal_roles')
-        self.assertEqual(self.plugin.userid_header, b'uid')
+        self.assertEqual(self.plugin.roles_header, 'portal_roles')
+        self.assertEqual(self.plugin.userid_header, 'uid')
 
         # Explicitly test the types.
-        # We want string, not unicode: when you save the properties form
-        # in the ZMI, you always get a string.
+        # We want string: when you save the properties form
+        # in the ZMI, you always get a string, in both Py 2 and 3
         # And we want tuples, not lists.
         self.assertIsInstance(self.plugin.allowed_roles, tuple)
-        self.assertIsInstance(self.plugin.allowed_roles[0], six.binary_type)
+        self.assertIsInstance(self.plugin.allowed_roles[0], str)
         self.assertIsInstance(self.plugin.deny_unauthorized, bool)
         self.assertIsInstance(self.plugin.memberdata_to_header, tuple)
-        self.assertIsInstance(self.plugin.memberdata_to_header[0], six.binary_type)
-        self.assertIsInstance(self.plugin.redirect_url, six.binary_type)
+        self.assertIsInstance(self.plugin.memberdata_to_header[0], str)
+        self.assertIsInstance(self.plugin.redirect_url, str)
         self.assertIsInstance(self.plugin.required_headers, tuple)
-        self.assertIsInstance(self.plugin.required_headers[0], six.binary_type)
-        self.assertIsInstance(self.plugin.roles_header, six.binary_type)
-        self.assertIsInstance(self.plugin.userid_header, six.binary_type)
+        self.assertIsInstance(self.plugin.required_headers[0], str)
+        self.assertIsInstance(self.plugin.roles_header, str)
+        self.assertIsInstance(self.plugin.userid_header, str)
 
     def test_import_purge_false(self):
         """Test purge=false."""
@@ -234,7 +234,7 @@ class TestImport(ExportImportBaseTestCase):
         self.assertTupleEqual(self.plugin.memberdata_to_header, ())
         self.assertEqual(self.plugin.redirect_url, '')
         self.assertTupleEqual(self.plugin.required_headers, ())
-        self.assertEqual(self.plugin.userid_header, b'my_uid')
+        self.assertEqual(self.plugin.userid_header, 'my_uid')
 
     def test_import_no_plugin(self):
         """Test that import does not fail when plugin is not there."""
@@ -274,7 +274,7 @@ class TestImport(ExportImportBaseTestCase):
             'userid_header': 'my_uid',
         }
         import_properties(self._makeContext(json.dumps(settings)))
-        self.assertEqual(self.plugin.userid_header, b'my_uid')
+        self.assertEqual(self.plugin.userid_header, 'my_uid')
         marker = object()
         self.assertIs(getattr(self.plugin, 'unknown', marker), marker)
 
@@ -322,7 +322,6 @@ class TestExport(ExportImportBaseTestCase):
         context = self._makeContext()
         export_properties(context)
         # The properties are exported by json.dumps, which returns str in both Python 2 and 3.
-        # self.assertIsInstance(context.get_exported_data(), six.binary_type)
         self.assertIsInstance(context.get_exported_data(), str)
         # json.loads always gives unicode
         self.assertDictEqual(

--- a/src/pas/plugins/headers/tests/test_functional.py
+++ b/src/pas/plugins/headers/tests/test_functional.py
@@ -108,7 +108,7 @@ class TestFull(unittest.TestCase):
         # after the headers are no longer there.
         self.plugin.create_ticket = True
         # On Unauthorized, redirect to our special headerlogin page.
-        self.plugin.redirect_url = 'headerlogin'
+        self.plugin.redirect_url = '/headerlogin'
         # This is the main user id header.
         self.plugin.userid_header = 'REMOTEUSER'
         transaction.commit()

--- a/src/pas/plugins/headers/tests/test_plugins.py
+++ b/src/pas/plugins/headers/tests/test_plugins.py
@@ -363,6 +363,7 @@ class HeaderPluginUnitTests(unittest.TestCase):
 
         # Check the response.
         out.seek(0)
+        # Yes, this must be bytes, not 'str' on Python 3.
         self.assertIn(
             b'ERROR: denying any unauthorized access.',
             out.read())

--- a/src/pas/plugins/headers/tests/test_utils.py
+++ b/src/pas/plugins/headers/tests/test_utils.py
@@ -5,7 +5,7 @@ from plone import api
 import unittest
 
 
-class TestUtils(unittest.TestCase):
+class TestGetPlugin(unittest.TestCase):
     """Test that utils.py works."""
 
     layer = PAS_PLUGINS_HEADERS_INTEGRATION_TESTING
@@ -44,3 +44,33 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(plugin.id, PLUGIN_ID)
         self.assertIsInstance(plugin, HeaderPlugin)
         self.assertEqual(plugin, getattr(self.portal.acl_users, PLUGIN_ID))
+
+
+class TestSafeMakeString(unittest.TestCase):
+    """Test that utils.py works."""
+
+    def test_safe_make_string(self):
+        from pas.plugins.headers.utils import safe_make_string
+
+        self.assertEqual(safe_make_string(b''), '')
+        self.assertEqual(safe_make_string(''), '')
+        self.assertEqual(safe_make_string(u''), '')
+
+        # e-with-an-accent.
+        if isinstance('', bytes):
+            # On Python 2 we expect an encoded string.
+            expected = '\xc3\xab'
+        else:
+            # On Python 3 we expect a native string.
+            expected = '\xeb'
+        self.assertEqual(safe_make_string(b'\xc3\xab'), expected)
+        self.assertEqual(safe_make_string(expected), expected)
+        self.assertEqual(safe_make_string(u'\xeb'), expected)
+
+        self.assertEqual(safe_make_string([1, b'two', 'three', u'four']), [1, 'two', 'three', 'four'])
+
+        self.assertEqual(safe_make_string(0), 0)
+        self.assertEqual(safe_make_string(None), None)
+        self.assertEqual(safe_make_string([]), [])
+        self.assertEqual(safe_make_string(()), [])
+        self.assertEqual(safe_make_string(set()), [])

--- a/src/pas/plugins/headers/utils.py
+++ b/src/pas/plugins/headers/utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from pas.plugins.headers.plugins import HeaderPlugin
 from Products.CMFCore.utils import getToolByName
 
 import six
@@ -16,6 +15,10 @@ def get_plugin(context):
     plugin = getattr(pas, PLUGIN_ID, None)
     if plugin is None:
         return
+
+    # Import here to avoid a circular import
+    from pas.plugins.headers.plugins import HeaderPlugin
+
     if not isinstance(plugin, HeaderPlugin):
         return
     return plugin

--- a/src/pas/plugins/headers/utils.py
+++ b/src/pas/plugins/headers/utils.py
@@ -2,6 +2,8 @@
 from pas.plugins.headers.plugins import HeaderPlugin
 from Products.CMFCore.utils import getToolByName
 
+import six
+
 
 PLUGIN_ID = 'request_headers'
 
@@ -17,3 +19,19 @@ def get_plugin(context):
     if not isinstance(plugin, HeaderPlugin):
         return
     return plugin
+
+
+def safe_make_string(value):
+    """Make bytes/text value a string.
+
+    If value is a list/tuple, do this for each item.  Return a list.
+
+    If a value is an integer or some other non-bytes/string/text type,
+    let it remain the same.
+    """
+    if isinstance(value, (list, tuple, set)):
+        return [safe_make_string(v) for v in value]
+    try:
+        return six.ensure_str(value)
+    except TypeError:
+        return value


### PR DESCRIPTION
On Python 3 we were setting the properties as bytes, which was wrong.
