### PR TITLE
Added option ``default_roles``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added option ``default_roles``.
+  These roles are given when a user is successfully authenticated by this plugin.
+  You always automatically get the Authenticated role.
+  But you may want to give everyone the Member role.
+  This is not checked against the allowed roles.
+  [maurits]
 
 
 1.3.2 (2021-12-02)

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ These are the properties that you can edit:
     You can also combine several headers:
     ``propname|header_with_firstname header_with_lastname``.
 
-``create_ticket``.
+``create_ticket``:
   Create an authentication ticket (``__ac`` cookie) with ``plone.session``.
   Default: false.
   When reading headers, this checks if Plone knows this user.
@@ -118,6 +118,12 @@ These are the properties that you can edit:
   Then you could let your frontend server (nginx, Apache) only set the headers for some urls, instead of for all.
   Note that this does not work for root Zope users, and it does not take over properties and roles.
   See also `issue 6 <https://github.com/collective/pas.plugins.headers/issues/6>`_.
+
+``default_roles``:
+  Default roles to add when a user is successfully authenticated by this plugin.
+  You always automatically get the Authenticated role.
+  But you may want to give everyone the Member role.
+  This is not checked against the allowed roles.
 
 
 Configuration via GenericSetup
@@ -137,6 +143,9 @@ Full example:
             "Zebra"
         ],
         "create_ticket": true,
+        "default_roles": [
+            "Member"
+        ],
         "deny_unauthorized": true,
         "memberdata_to_header": [
             "uid|HEADER_uid|lower",

--- a/src/pas/plugins/headers/tests/test_exportimport.py
+++ b/src/pas/plugins/headers/tests/test_exportimport.py
@@ -294,6 +294,7 @@ class TestExport(ExportImportBaseTestCase):
             """{
 "allowed_roles": [],
 "create_ticket": false,
+"default_roles": [],
 "deny_unauthorized": false,
 "memberdata_to_header": [],
 "redirect_url": "",
@@ -306,6 +307,7 @@ class TestExport(ExportImportBaseTestCase):
             json.loads(context.get_exported_data()),
             {
                 'allowed_roles': [],
+                'default_roles': [],
                 'deny_unauthorized': False,
                 'create_ticket': False,
                 'memberdata_to_header': [],
@@ -328,6 +330,7 @@ class TestExport(ExportImportBaseTestCase):
             json.loads(context.get_exported_data()),
             {
                 'allowed_roles': ['root'],
+                'default_roles': [],
                 'deny_unauthorized': True,
                 'create_ticket': True,
                 'memberdata_to_header': ['foo|bar'],

--- a/src/pas/plugins/headers/tests/test_plugins.py
+++ b/src/pas/plugins/headers/tests/test_plugins.py
@@ -183,7 +183,7 @@ class HeaderPluginUnitTests(unittest.TestCase):
         request.addHeader(roles_header, '  one two three   ')
         self.assertEqual(
             plugin.getRolesForPrincipal(user, request),
-            ['one', 'two', 'three'])
+            ['one', 'three', 'two'])
         # We can restrict the roles that we take over.
         plugin.allowed_roles = ('one', 'three')
         self.assertEqual(
@@ -198,8 +198,16 @@ class HeaderPluginUnitTests(unittest.TestCase):
         self.assertEqual(
             plugin.getRolesForPrincipal(user, request),
             ['One', 'THRee'])
-        # If we unset the roles_header, no roles are found.
+        # We may have default roles, when the automatic Authenticated role
+        # is not enough.
+        plugin.default_roles = ('Member',)
+        self.assertEqual(plugin.getRolesForPrincipal(user, request), ['Member', 'One', 'THRee'])
+        plugin.default_roles = ('Member', 'Raccoon')
+        self.assertEqual(plugin.getRolesForPrincipal(user, request), ['Member', 'One', 'Raccoon', 'THRee'])
+        # If we unset the roles_header, no roles are found, except the default roles.
         plugin.roles_header = ''
+        self.assertEqual(plugin.getRolesForPrincipal(user, request), ['Member', 'Raccoon'])
+        plugin.default_roles = ()
         self.assertEqual(plugin.getRolesForPrincipal(user, request), [])
 
     def test_parse_memberdata_to_header(self):

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ commands_pre =
     plone52: {envbindir}/buildout -Nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     plone60: {envbindir}/buildout -Nc {toxinidir}/test-6.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
-    {envbindir}/test
+    {envbindir}/test []


### PR DESCRIPTION
These roles are given when a user is successfully authenticated by this plugin.
You always automatically get the Authenticated role.
But you may want to give everyone the Member role.
This is not checked against the allowed roles.