### PR TITLE
Breaking redirection cycle by checking for usereid_header before redirecting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Fix: Breaking redirection cycle by checking for ``userid_header`` before redirecting
+  [@gogobd]
+
 - Update addon using plone.meta
   [@jensens]
 

--- a/src/pas/plugins/headers/plugins.py
+++ b/src/pas/plugins/headers/plugins.py
@@ -158,7 +158,7 @@ class HeaderPlugin(BasePlugin):
             # Yes, this must be bytes, not 'str' on Python 3.
             response.write(b"ERROR: denying any unauthorized access.\n")
             return True
-        if self.redirect_url:
+        if self.redirect_url and not request.get("HTTP_" + self.userid_header):
             url = self.redirect_url
             if isinstance(url, bytes):
                 url = url.decode("utf-8")

--- a/src/pas/plugins/headers/plugins.py
+++ b/src/pas/plugins/headers/plugins.py
@@ -158,7 +158,7 @@ class HeaderPlugin(BasePlugin):
             # Yes, this must be bytes, not 'str' on Python 3.
             response.write(b"ERROR: denying any unauthorized access.\n")
             return True
-        if self.redirect_url and not request.get("HTTP_" + self.userid_header):
+        if self.redirect_url and not self._get_userid(request):
             url = self.redirect_url
             if isinstance(url, bytes):
                 url = url.decode("utf-8")

--- a/src/pas/plugins/headers/tests/test_plugins.py
+++ b/src/pas/plugins/headers/tests/test_plugins.py
@@ -371,9 +371,7 @@ class HeaderPluginUnitTests(unittest.TestCase):
         out.seek(0)
         self.assertEqual(out.read(), b"")
         self.assertEqual(response.getStatus(), 302)  # Check for Redirect
-        self.assertNotEqual(
-            response.headers["location"], f"{url}?came_from={request.URL}"
-        )
+        self.assertEqual(response.headers["location"], f"{url}?came_from={request.URL}")
 
     def test_challenge_break_redirect_cycle(self):
         # Prepare the plugin.

--- a/src/pas/plugins/headers/tests/test_plugins.py
+++ b/src/pas/plugins/headers/tests/test_plugins.py
@@ -370,7 +370,35 @@ class HeaderPluginUnitTests(unittest.TestCase):
         # Check the response.
         out.seek(0)
         self.assertEqual(out.read(), b"")
-        self.assertEqual(response.headers["location"], f"{url}?came_from={request.URL}")
+        self.assertEqual(response.getStatus(), 302)  # Check for Redirect
+        self.assertNotEqual(
+            response.headers["location"], f"{url}?came_from={request.URL}"
+        )
+
+    def test_challenge_break_redirect_cycle(self):
+        # Prepare the plugin.
+        from pas.plugins.headers.plugins import HeaderPlugin
+
+        plugin = HeaderPlugin()
+        url = "https://example.org/saml-login"
+        plugin.redirect_url = url
+
+        # Prepare the request.
+        request = HeaderRequest()
+        auth_header = "SAML_id"
+        plugin.userid_header = auth_header
+        request.addHeader(auth_header, "my uid")
+        out = BytesIO()
+        response = HTTPResponse(stdout=out)
+
+        # When the plugin does not make a challenge, it must returns None
+        self.assertIsNone(plugin.challenge(request, response))
+
+        # Check the response -  it must not contain a redirection ("location")
+        out.seek(0)
+        self.assertEqual(out.read(), b"")
+        self.assertEqual(response.getStatus(), 200)
+        self.assertIsNone(response.headers.get("location"))
 
     def test_extractCredentials(self):
         from pas.plugins.headers.plugins import HeaderPlugin


### PR DESCRIPTION
Check if the authentication header is present already before performing a redirection.
fixes #18 